### PR TITLE
[JENKINS-27945] Enable cluster support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509.4</version><!-- which version of Jenkins is this plugin built against? -->
+        <version>1.608</version><!-- which version of Jenkins is this plugin built against? -->
     </parent>
 
     <artifactId>websphere-deployer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,37 +53,37 @@
             <groupId>com.ibm.ws</groupId>
             <artifactId>admin</artifactId>
             <version>8.5.0</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>orb</artifactId>
             <version>8.5.0</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>liberty-connector</artifactId>
             <version>8.5.5</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>liberty-rest-connector</artifactId>
             <version>8.5.5</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>liberty-basic</artifactId>
             <version>8.5.5</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>liberty-endpoint</artifactId>
             <version>8.5.5</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
@@ -47,6 +47,7 @@ public class WebSphereDeployerPlugin extends Notifier {
     private final String node;
     private final String cell;
     private final String server;
+    private final String cluster;
     private final String artifacts;
     private final String clientKeyPassword;
     private final String clientTrustPassword;
@@ -68,6 +69,7 @@ public class WebSphereDeployerPlugin extends Notifier {
                                    String node,
                                    String cell,
                                    String server,
+                                   String cluster,
                                    String clientKeyPassword,
                                    String clientTrustPassword,
                                    String earLevel,
@@ -86,6 +88,7 @@ public class WebSphereDeployerPlugin extends Notifier {
         this.node = node;
         this.cell = cell;
         this.server = server;
+        this.cluster = cluster;
         this.autoStart = autoStart;
         this.clientKeyPassword = Scrambler.scramble(clientKeyPassword);
         this.clientTrustPassword = Scrambler.scramble(clientTrustPassword);
@@ -149,6 +152,10 @@ public class WebSphereDeployerPlugin extends Notifier {
 
     public String getServer() {
         return server;
+    }
+
+    public String getCluster() {
+        return cluster;
     }
 
     public String getCell() {
@@ -270,6 +277,7 @@ public class WebSphereDeployerPlugin extends Notifier {
         service.setTargetCell(env.expand(getCell()));
         service.setTargetNode(env.expand(getNode()));
         service.setTargetServer(env.expand(getServer()));
+        service.setTargetCluster(env.expand(getCluster()));
         service.connect();
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin/config.jelly
@@ -49,6 +49,9 @@
           <f:entry title="Target Server" field="server">
             <f:textbox />
           </f:entry>
+          <f:entry title="Target Cluster" field="cluster">
+            <f:textbox />
+          </f:entry>
           <f:entry title="Deployment Timeout (minutes)" field="deploymentTimeout">
             <f:textbox />
           </f:entry>       

--- a/src/main/resources/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin/help-cluster.html
+++ b/src/main/resources/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin/help-cluster.html
@@ -1,0 +1,5 @@
+<div>
+    The cluster to deploy to. To find the cluster you want to deploy to, simple look at the path where IBM WebSphere Application Server was installed. (i.e. '[WAS_INSTALL_ROOT]/profiles/[PROFILE]/config/cells/[CELL_NAME]/clusters/[CLUSTER_NAME]').
+
+    This property is optional, if left blank it is assumed that no application cluster is defined and the plugin will try to deploy directly on the server. If you have defined a cluster of applications though, you have to specify this property.
+</div>


### PR DESCRIPTION
This PR enables support for environments with application clusters defined.

It also fixes the scope of WebSphere dependencies (with runtime scope the plugin files could not compile even when dependencies were in place).

This PR closes the following issue: https://issues.jenkins-ci.org/browse/JENKINS-27945
