### PR TITLE
Fix context-root generation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
@@ -118,7 +118,7 @@ public class WebSphereDeploymentService extends AbstractDeploymentService {
             // find uri attribute in context-root element
             Element contextRoot = (Element) doc.getElementsByTagName("context-root").item(0);
             String uri = contextRoot.getAttribute("uri");
-            uri += uri.startsWith("/") ? "" : "/";
+            uri = uri.startsWith("/") ? "" : "/" + uri;
             return uri;
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
The changes introduced by PR #6 generated a wrong context root when no `/` was present.

This PR fixes that behaviour.
