### PR TITLE
Add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+target
+*.iml


### PR DESCRIPTION
This PR adds a basic `.gitignore` file in order to ignore common files (IDE, maven `target` directories).
