### PR TITLE
Deploy when unstable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
@@ -225,8 +225,7 @@ public class WebSphereDeployerPlugin extends Notifier {
                 service.disconnect();
             }
         } else {
-        	listener.getLogger().println("Unable to deploy to IBM WebSphere Application Server, Build Result = FAILURE");
-        	build.setResult(Result.FAILURE);
+            listener.getLogger().println("Unable to deploy to IBM WebSphere Application Server, Build Result = " + build.getResult());
         }
         return true;
     }

--- a/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
@@ -58,6 +58,7 @@ public class WebSphereDeployerPlugin extends Notifier {
     private final boolean verbose;
     private final boolean distribute;
     private final boolean rollback;
+    private final boolean unstableDeploy;
     private final WebSphereSecurity security;
 
     @DataBoundConstructor
@@ -79,6 +80,7 @@ public class WebSphereDeployerPlugin extends Notifier {
                                    boolean verbose,
                                    boolean distribute,
                                    boolean rollback,
+                                   boolean unstableDeploy,
                                    String classLoaderPolicy,
                                    String classLoaderOrder) {
     	this.context = context;
@@ -97,6 +99,7 @@ public class WebSphereDeployerPlugin extends Notifier {
         this.verbose = verbose;
         this.distribute = distribute;
         this.rollback = rollback;
+        this.unstableDeploy = unstableDeploy;
         this.security = security;
         this.classLoaderPolicy = classLoaderPolicy;
         this.classLoaderOrder = classLoaderOrder;
@@ -151,6 +154,10 @@ public class WebSphereDeployerPlugin extends Notifier {
     	return rollback;
     }
 
+    public boolean isUnstableDeploy() {
+        return unstableDeploy;
+    }
+
     public String getIpAddress() {
         return ipAddress;
     }
@@ -185,7 +192,7 @@ public class WebSphereDeployerPlugin extends Notifier {
 
     @Override
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-        if(build.getResult().equals(Result.SUCCESS)) {
+        if(shouldDeploy(build.getResult())) {
         	WebSphereDeploymentService service = new WebSphereDeploymentService();
         	Artifact artifact = null;
             try {            	
@@ -228,6 +235,12 @@ public class WebSphereDeployerPlugin extends Notifier {
             listener.getLogger().println("Unable to deploy to IBM WebSphere Application Server, Build Result = " + build.getResult());
         }
         return true;
+    }
+
+    private boolean shouldDeploy(Result result) {
+        if (result.equals(Result.SUCCESS)) return true;
+        if (unstableDeploy && result.equals(Result.UNSTABLE)) return true;
+        return false;
     }
     
     private void log(BuildListener listener,String data) {

--- a/src/main/resources/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin/config.jelly
@@ -100,6 +100,9 @@
           <f:entry title="Remote App. Install Path" field="installPath">
             <f:textbox />
           </f:entry>           
+          <f:entry title="Deploy if build is unstable" field="unstableDeploy">
+            <f:checkbox checked="${instance.unstableDeploy}" default="true"/>
+          </f:entry>
           <f:entry title="Distribute Application" field="distribute">
             <f:checkbox checked="${instance.distribute}" default="true"/>
           </f:entry>                    


### PR DESCRIPTION
Current IBM WebSphere Application Server plugin does not perform deploy on target application server when build is classified as `UNSTABLE`.

This PR adds a checkbox on the plugin configuration where the user can decide to override this setting  and proceed with the deploy even when there are test failures.

Moreover this PR fixes a small undesired behaviour where the plugin would change the `Result` of the global build to `FAILED` when it doesn't run: the build outcome should retain its status (failed, unstable or aborted) even when the plugin doesn't run.
