### PR TITLE
Do not clear system properties on disconnect

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.websphere.services.deployment;
 
+import com.ibm.ws.management.AdminClientImpl;
 import hudson.model.BuildListener;
 
 import java.io.File;
@@ -428,15 +429,6 @@ public class WebSphereDeploymentService extends AbstractDeploymentService {
     }
 
     public void disconnect() {
-		System.clearProperty("javax.net.ssl.trustStore");
-		System.clearProperty("javax.net.ssl.keyStore");
-		System.clearProperty("javax.net.ssl.trustStorePassword");
-		System.clearProperty("javax.net.ssl.keyStorePassword");
-		System.clearProperty("com.ibm.ssl.trustStore");
-		System.clearProperty("com.ibm.ssl.keyStore");
-		System.clearProperty("com.ibm.ssl.trustStorePassword");
-		System.clearProperty("com.ibm.ssl.keyStorePassword");
-		System.clearProperty("com.ibm.ssl.performURLHostNameVerification");
     	if(client != null) {
     		client.getConnectorProperties().clear();
     		client = null;


### PR DESCRIPTION
On a recent commit the disconnect method clears several Java system properties. 

In general I don't feel a plugin of a job should have such a widespread side effect on the system configuration. 

Is there a particular reason why those properties are removed? 
Otherwise this PR reverts that change.
