### PR TITLE
Block editing of EAR file upon validation.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
@@ -231,8 +231,6 @@ public class WebSphereDeploymentService extends AbstractDeploymentService {
            throw new DeploymentServiceException("Unable to complete all task data for deployment preparation. Reason: " + Arrays.toString(validationResult));
         }
 
-        controller.saveAndClose();
-
         preferences.put(AppConstants.APPDEPL_LOCALE, Locale.getDefault());
         preferences.put(AppConstants.APPDEPL_ARCHIVE_UPLOAD, Boolean.TRUE);
         preferences.put(AppConstants.APPDEPL_PRECOMPILE_JSP, artifact.isPrecompile());


### PR DESCRIPTION
The call to `controller.saveAndClose()` causes the creation of WebSphere
specific metadata files in the EAR that's going to be deployed.

The wsadmin thin client though is not able to perform the same level of
scanning that WebSphere Application Server does and therefore those
files might be generated invalid.

The issue arise when these files are generated invalid cause, if
WebSphere Application Server finds the files already generated in the
EAR that it receives, it will not perform any further scanning.

This commit prevents saving the generated metadata files, while still
letting the wsadmin thin client perform its validation phase.
