### PR TITLE
full synchronise nodes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere/services/deployment/WebSphereDeploymentService.java
@@ -583,5 +583,21 @@ public class WebSphereDeploymentService extends AbstractDeploymentService {
 		}
 		return distributionState;
     }
+	
+    /**
+     * Fully resynchronizes all nodes.
+     */
+    public void fullResynchronizeNodes() {
+        try {
+            ObjectName serverObject = new ObjectName("WebSphere:type=NodeSync,*");
+            Set<ObjectName> nodes = client.queryNames(serverObject, null);
+            for (ObjectName node : nodes) {
+                client.invoke(node, "sync", new Object[] {}, new String[] {});
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new DeploymentServiceException(e.getMessage(), e);
+        }
+    }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/websphere_deployer/WebSphereDeployerPlugin.java
@@ -228,6 +228,7 @@ public class WebSphereDeployerPlugin extends Notifier {
                     		updateArtifact(artifact,listener,service);
                     	}
                     }
+                    service.fullResynchronizeNodes();
                     startArtifact(artifact.getAppName(),listener,service);
                     if(rollback) {
                     	saveArtifactToRollbackRepository(build, listener, artifact);


### PR DESCRIPTION
I had some trouble deploying my ear on a WAS Network Deployment because the plugin could not start my application until the node on which it was installed was not synchronised.  I decided to write a small change to the plugin to synchronise all nodes before any attempt is made to start applications.